### PR TITLE
Add types for accountInfo, order, prices & time

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.4.3",
   "description": "A node API wrapper for Binance",
   "main": "dist",
+  "types": "types.d.ts",
   "scripts": {
     "build": "rm -rf dist && babel src -d dist",
     "test": "ava",

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,7 +1,7 @@
 declare module 'binance-api-node' {
   export default function(options?: { apiKey: string; apiSecret: string }): Binance
 
-  export interface AccountInfo {
+  export interface Account {
     balances: Array<Balance>
     buyerCommission: number
     canDeposit: boolean
@@ -20,7 +20,7 @@ declare module 'binance-api-node' {
   }
 
   export interface Binance {
-    accountInfo(): Promise<AccountInfo>
+    accountInfo(): Promise<Account>
     order(options: NewOrder): Promise<Order>
     prices(): Promise<{ [index: string]: string }>
     time(): Promise<number>

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,0 +1,79 @@
+declare module 'binance-api-node' {
+  export default function(options?: { apiKey: string; apiSecret: string }): Binance
+
+  export interface AccountInfo {
+    balances: Array<Balance>
+    buyerCommission: number
+    canDeposit: boolean
+    canTrade: boolean
+    canWithdraw: boolean
+    makerCommission: number
+    sellerCommission: number
+    takerCommission: number
+    updateTime: number
+  }
+
+  export interface Balance {
+    asset: string
+    free: string
+    locked: string
+  }
+
+  export interface Binance {
+    accountInfo(): Promise<AccountInfo>
+    order(options: NewOrder): Promise<Order>
+    prices(): Promise<{ [index: string]: string }>
+    time(): Promise<number>
+  }
+
+  export interface NewOrder {
+    icebergQty?: string
+    newClientOrderId?: string
+    price?: string
+    quantity: string
+    recvWindow?: number
+    side: OrderSide
+    stopPrice?: string
+    symbol: string
+    timeInForce?: TimeInForce
+    type: OrderType
+  }
+
+  interface Order {
+    clientOrderId: string
+    executedQty: string
+    icebergQty?: string
+    orderId: number
+    origQty: string
+    price: string
+    side: OrderSide
+    status: OrderStatus
+    stopPrice?: string
+    symbol: string
+    timeInForce: TimeInForce
+    transactTime: number
+    type: OrderType
+  }
+
+  export type OrderSide = 'BUY' | 'SELL'
+
+  export type OrderStatus =
+    | 'CANCELED'
+    | 'EXPIRED'
+    | 'FILLED'
+    | 'NEW'
+    | 'PARTIALLY_FILLED'
+    | 'PENDING_CANCEL'
+    | 'REJECTED'
+
+  export type OrderType =
+    | 'LIMIT'
+    | 'LIMIT_MAKER'
+    | 'MARKET'
+    | 'STOP_LOSS'
+    | 'STOP_LOSS_LIMIT'
+    | 'TAKE_PROFIT'
+    | 'TAKE_PROFIT_LIMIT'
+
+  export type TimeInForce = 'GTC' | 'IOC'
+}

--- a/types.d.ts
+++ b/types.d.ts
@@ -2,7 +2,7 @@ declare module 'binance-api-node' {
   export default function(options?: { apiKey: string; apiSecret: string }): Binance
 
   export interface Account {
-    balances: Array<Balance>
+    balances: Array<AssetBalance>
     buyerCommission: number
     canDeposit: boolean
     canTrade: boolean
@@ -13,7 +13,7 @@ declare module 'binance-api-node' {
     updateTime: number
   }
 
-  export interface Balance {
+  export interface AssetBalance {
     asset: string
     free: string
     locked: string


### PR DESCRIPTION
Here is my PR with an initial definition for the methods `accountInfo`, `order`, `prices` & `time` to kick-off TypeScript support. To make sure that the definitions are correct, I checked original payload responses as well as the official [Rest API for Binance](https://github.com/binance-exchange/binance-official-api-docs/blob/master/rest-api.md) (2017-12-01).

To be consistent with other Binance APIs, I synchronized the naming of the defined types with [Binance's Java API](https://github.com/binance-exchange/binance-java-api/):
- [Account.java](https://github.com/binance-exchange/binance-java-api/blob/master/src/main/java/com/binance/api/client/domain/account/Account.java)
- [AssetBalance.java](https://github.com/binance-exchange/binance-java-api/blob/master/src/main/java/com/binance/api/client/domain/account/AssetBalance.java)
- [NewOrder.java](https://github.com/binance-exchange/binance-java-api/blob/master/src/main/java/com/binance/api/client/domain/account/NewOrder.java)
- [Order.java](https://github.com/binance-exchange/binance-java-api/blob/master/src/main/java/com/binance/api/client/domain/account/Order.java)
- [OrderSide.java](https://github.com/binance-exchange/binance-java-api/blob/master/src/main/java/com/binance/api/client/domain/OrderSide.java)
- [OrderStatus.java](https://github.com/binance-exchange/binance-java-api/blob/master/src/main/java/com/binance/api/client/domain/OrderStatus.java)
- [OrderType.java](https://github.com/binance-exchange/binance-java-api/blob/master/src/main/java/com/binance/api/client/domain/OrderType.java)
- [TimeInForce.java](https://github.com/binance-exchange/binance-java-api/blob/master/src/main/java/com/binance/api/client/domain/TimeInForce.java)

The only thing were I have been unsure are the parameters used for `price`, `stopPrice` and `icebergQty`. The documentation here says that these are numbers (https://github.com/HyperCubeProject/binance-api-node#authenticated-rest-endpoints) but all other clients treat them as strings. I also guess these should be strings?

Here is an example on how this library can now be used with TypeScript:

```ts
import Binance, {Account, AssetBalance} from 'binance-api-node';

const client = Binance({
  apiKey: '...',
  apiSecret: '...',
});

client.accountInfo().then((info: Account) => {
  const balances: Array<AssetBalance> = info.balances;
  console.log(`Your account trades ${balances.length} assets.`);
});
```

Best from Berlin,
Benny