### PR TITLE
Fix close handle for `client.ws.depth`

### DIFF
--- a/src/websocket.js
+++ b/src/websocket.js
@@ -27,6 +27,8 @@ const depth = (payload, cb) => {
         askDepth: askDepth.map(a => zip(['price', 'quantity'], a)),
       })
     })
+
+    return w
   })
 
   return () => cache.forEach(w => w.close())

--- a/src/websocket.js
+++ b/src/websocket.js
@@ -6,7 +6,7 @@ import httpMethods from 'http'
 const BASE = 'wss://stream.binance.com:9443/ws'
 
 const depth = (payload, cb) => {
-  const cache = (Array.isArray(payload) ? payload : [payload]).forEach(symbol => {
+  const cache = (Array.isArray(payload) ? payload : [payload]).map(symbol => {
     const w = new WebSocket(`${BASE}/${symbol.toLowerCase()}@depth`)
     w.on('message', msg => {
       const {


### PR DESCRIPTION
I was testing `client.ws.depth` and noticed that the close handle doesn't work because the cache assignment is done with a `forEach` execution.

I fixed it by using `map` (all other `cache` assignments are also done with `map`).

This prevents the following error:

> TypeError: Cannot read property 'forEach' of undefined

You can test it with the following snippet:

```js
const close = client.ws.depth('ETHBTC', depth => {
  console.log('new data', depth);
  close();
})
```