### PR TITLE
added forgotten "export" keyword for Symbol interface

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -109,7 +109,7 @@ declare module 'binance-api-node' {
         | SymbolMaxNumOrdersFilter
         | SymbolMaxAlgoOrdersFilter;
 
-    interface Symbol {
+    export interface Symbol {
         symbol: string;
         status: string;
         baseAsset: string;


### PR DESCRIPTION
added forgotten "export" keyword for Symbol interface

@balthazar   I would really appreciate if you add changes from this #53  and #52 commits to npm )