### PR TITLE
Expose error codes

### DIFF
--- a/src/http.js
+++ b/src/http.js
@@ -21,7 +21,9 @@ const makeQueryString = q =>
 const sendResult = call =>
   call.then(res => Promise.all([res, res.json()])).then(([res, json]) => {
     if (!res.ok) {
-      throw new Error(json.msg || `${res.status} ${res.statusText}`)
+      const error = new Error(json.msg || `${res.status} ${res.statusText}`)
+      error.code = json.code
+      throw error
     }
 
     return json

--- a/test/authenticated.js
+++ b/test/authenticated.js
@@ -128,6 +128,20 @@ test.serial('[REST] tradesHistory', async t => {
   t.is(trades.length, 500)
 })
 
+test.serial('[REST] error code', async t => {
+  try {
+    await client.orderTest({
+      symbol: 'TRXETH',
+      side: 'SELL',
+      type: 'LIMIT',
+      quantity: '1337.00000000',
+      price: '1.00000000',
+    })
+  } catch (e) {
+    t.is(e.code, -1100)
+  }
+})
+
 test.serial('[WS] user', async t => {
   const clean = await client.ws.user()
   t.truthy(clean)

--- a/test/authenticated.js
+++ b/test/authenticated.js
@@ -134,7 +134,7 @@ test.serial('[REST] error code', async t => {
       symbol: 'TRXETH',
       side: 'SELL',
       type: 'LIMIT',
-      quantity: '1337.00000000',
+      quantity: '-1337.00000000',
       price: '1.00000000',
     })
   } catch (e) {


### PR DESCRIPTION
This PR solves HyperCubeProject/binance-api-node/issues/58 - I am adding the `code` from the error payload to the error object, so that it can be checked.

**Test code:**

```js
const Binance = require('./dist/index').default

const client = Binance({
  apiKey,
  apiSecret,
})

const order = {'symbol': 'TRXETH', 'side': 'SELL', 'type': 'LIMIT', 'quantity': '-1337', 'price': '1.00000000'}

client.order(order).catch(error => console.log('Error code', error.code))
```