### PR TITLE
Expose error code in definition file

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -36,6 +36,11 @@ declare module 'binance-api-node' {
         openOrders(options: { symbol: string }): Promise<QueryOrderResult[]>;
     }
 
+    export interface HttpError extends Error {
+        code: number;
+        message: string;
+    }
+
     export interface WebSocket {
         depth: (pair: string, callback: (depth: Depth) => void) => Function;
         partialDepth: (options: { symbol: string, level: number }, callback: (depth: PartialDepth) => void) => Function;


### PR DESCRIPTION
For HTTP errors we are adding the `code` property from the original `FetchError` to our own error (https://github.com/HyperCubeProject/binance-api-node/pull/60), so I made this change visible in the definition file.