### PR TITLE
Error codes can be strings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -37,7 +37,7 @@ declare module 'binance-api-node' {
     }
 
     export interface HttpError extends Error {
-        code: number;
+        code: number | string;
         message: string;
     }
 


### PR DESCRIPTION
Under some circumstances, the error code can be 'ENOENT' or even 'ENOTFOUND'. See: https://github.com/HyperCubeProject/binance-api-node/issues/64#issuecomment-372120664