### PR TITLE
Use safe authenticated methods for tests

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -107,7 +107,7 @@ test.serial('[REST] allBookTickers', async t => {
 
 test.serial('[REST] Signed call without creds', async t => {
   try {
-    await client.order({ symbol: 'ETHBTC', side: 'BUY', quantity: 1 })
+    await client.accountInfo()
   } catch (e) {
     t.is(e.message, 'You need to pass an API key and secret to make authenticated calls.')
   }


### PR DESCRIPTION
Use a safe authenticated method in tests. In case auth credentials are loaded, this will prevent an order from being executed against the user's account.