### PR TITLE
fix: aggTrades call returns list of aggregated trades

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -33,7 +33,7 @@ declare module 'binance-api-node' {
 
     export interface Binance {
         accountInfo(options?: { useServerTime: boolean }): Promise<Account>;
-        aggTrades(options?: { symbol: string, fromId?: string, startTime?: number, endTime?: number, limit?: number }): Promise<AggregatedTrade>;
+        aggTrades(options?: { symbol: string, fromId?: string, startTime?: number, endTime?: number, limit?: number }): Promise<AggregatedTrade[]>;
         allBookTickers(): Promise<{ [key: string]: Ticker }>;
         book(options: { symbol: string, limit?: number }): Promise<OrderBook>;
         exchangeInfo(): Promise<ExchangeInfo>;


### PR DESCRIPTION
According to the API docs at https://github.com/binance-exchange/binance-official-api-docs/blob/master/rest-api.md#compressedaggregate-trades-list

The /aggTrades call returns a list of type `AggregatedTrade`, therefore the current type is wrong and should be `AggregatedTrade[]` instead.