### PR TITLE
Added parentheses on function call inside setInterval

### DIFF
--- a/src/websocket.js
+++ b/src/websocket.js
@@ -255,7 +255,7 @@ const user = opts => cb => {
     const w = openWebSocket(`${BASE}/${listenKey}`)
     w.onmessage = (msg) => (userEventHandler(cb)(msg))
 
-    const int = setInterval(keepStreamAlive(keepDataStream, listenKey), 50e3)
+    const int = setInterval(()=>{keepStreamAlive(keepDataStream, listenKey)}, 50e3)
     keepStreamAlive(keepDataStream, listenKey)()
 
     return (options) => {

--- a/src/websocket.js
+++ b/src/websocket.js
@@ -255,7 +255,9 @@ const user = opts => cb => {
     const w = openWebSocket(`${BASE}/${listenKey}`)
     w.onmessage = (msg) => (userEventHandler(cb)(msg))
 
-    const int = setInterval(()=>{keepStreamAlive(keepDataStream, listenKey)}, 50e3)
+    const int = setInterval(() => {
+      keepStreamAlive(keepDataStream, listenKey);
+    }, 50e3);
     keepStreamAlive(keepDataStream, listenKey)()
 
     return (options) => {

--- a/src/websocket.js
+++ b/src/websocket.js
@@ -262,7 +262,7 @@ const user = opts => cb => {
     w.onmessage = (msg) => (userEventHandler(cb)(msg))
 
     const int = setInterval(() => {
-      keepStreamAlive(keepDataStream, listenKey)
+      keepStreamAlive(keepDataStream, listenKey)()
     }, 50e3)
     keepStreamAlive(keepDataStream, listenKey)()
 

--- a/src/websocket.js
+++ b/src/websocket.js
@@ -256,7 +256,7 @@ const user = opts => cb => {
     w.onmessage = (msg) => (userEventHandler(cb)(msg))
 
     const int = setInterval(() => {
-      keepStreamAlive(keepDataStream, listenKey)
+      keepStreamAlive(keepDataStream, listenKey)()
     }, 50e3)
     keepStreamAlive(keepDataStream, listenKey)()
 

--- a/src/websocket.js
+++ b/src/websocket.js
@@ -256,8 +256,8 @@ const user = opts => cb => {
     w.onmessage = (msg) => (userEventHandler(cb)(msg))
 
     const int = setInterval(() => {
-      keepStreamAlive(keepDataStream, listenKey);
-    }, 50e3);
+      keepStreamAlive(keepDataStream, listenKey)
+    }, 50e3)
     keepStreamAlive(keepDataStream, listenKey)()
 
     return (options) => {


### PR DESCRIPTION
keepStreamAlive is a function returning a function.  The function being returned is the actual one required to keep the listenKey alive, however it's never being called in the setInterval. So after 60 mins of time, the listenKey will expire and the websocket connection will be disconnected by binance.

I think
`export const keepStreamAlive = (method, listenKey) => () => method({ listenKey })` could be `export const keepStreamAlive = (method, listenKey) => { method({ listenKey }) }` (and then we don't need the extra parens), but not sure the original thought process, so left it as is.


@balthazar 