### PR TITLE
enable the userData websocket endpoint to reconnect gracefully

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "test": "ava",
     "cover": "nyc ava",
     "report": "npm run cover && nyc report --reporter=text-lcov | coveralls",
-    "lint": "eslint src"
+    "lint": "eslint src",
+    "prepare": "npm run build"
   },
   "dependencies": {
     "html5-websocket": "^2.0.2",

--- a/src/websocket.js
+++ b/src/websocket.js
@@ -277,7 +277,7 @@ const user = opts => cb => {
      if (currentListenKey) {
        clearInterval(int)
        
-       const p = closeDataStream({ currentListenKey })
+       const p = closeDataStream({ listenKey: currentListenKey })
        
        if (catch_errors) {
          p.catch((err) => (0))


### PR DESCRIPTION
Thanks for your module!

I noticed a problem related to the userData websocket endpoint, which I think is probably the same as the ones mentioned in #123  and #110.

The userData endpoint requires to obtain, keep alive, and delete a listenKey via the REST API, but this requirement isn't taken into account with the auto-reconnecting websocket.

1) The keep-alives, which are sent from an interval, can very well fail, especially with a spotty internet connection -> that would then cause an unhandled promise rejection, crashing the entire app from the internals of binance-api-node module.

2) I was frequently getting the same "This listenKey does not exist." error from the binance API as the described in the aforementioned issues. I think it's related to either the keep-alive requests not going through for whatever reason (maybe timing out, etc...), or it's simply a problem on binance's end. In any case, this would also crash the app then, with no good way to handle the error, since the module currently assumes the listenKey doesn't need to be changed after reconnect.

In this pull request, I'm trying to enable the expected auto-reconnecting behavior, even if the REST API requests fail, e.g. by hiding errors happening within the internals, but still exposing errors happening during the endpoint setup/tear-down via the client app api.