### PR TITLE
Fix incorrect RateLimit type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -87,7 +87,7 @@ declare module 'binance-api-node' {
         | '1M';
 
     export type RateLimitType =
-        | 'REQUESTS'
+        | 'REQUESTS_WEIGHT'
         | 'ORDERS';
 
     export type RateLimitInterval =


### PR DESCRIPTION
`RateLimitType` was incorrectly defined as
```
    export type RateLimitType =
        | 'REQUESTS'
        | 'ORDERS';
```
That is now fixed.