### PR TITLE
Fix wrong limit for candles REST endpoint in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ console.log(await client.candles({ symbol: 'ETHBTC' }))
 |--- |--- |--- |--- |--- |
 |symbol|String|true|
 |interval|String|false|`5m`|`1m`, `3m`, `5m`, `15m`, `30m`, `1h`, `2h`,<br>`4h`, `6h`, `8h`, `12h`, `1d`, `3d`, `1w`, `1M`|
-|limit|Number|false|`500`|Max `500`|
+|limit|Number|false|`500`|Max `1000`|
 |startTime|Number|false|
 |endTime|Number|false|
 


### PR DESCRIPTION
The limit according the official Binance docs are 1000 candles, the limit is 500 according to these docs. There is also no code limiting the amount of candles you can request, so I think this is simply an error in the docs.