### PR TITLE
fixing interface for partialDepth

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -70,7 +70,7 @@ declare module 'binance-api-node' {
 
     export interface WebSocket {
         depth: (pair: string | string[], callback: (depth: Depth) => void) => Function;
-        partialDepth: (options: { symbol: string, level: number }, callback: (depth: PartialDepth) => void) => Function;
+        partialDepth: (options: { symbol: string, level: number } | [{ symbol: string, level: number }], callback: (depth: PartialDepth) => void) => Function;
         ticker: (pair: string, callback: (ticker: Ticker) => void) => Function;
         allTickers: (callback: (tickers: Ticker[]) => void) => Function;
         candles: (pair: string, period: string, callback: (ticker: Candle) => void) => Function;


### PR DESCRIPTION
According to the first lines of the function, this also supports an array:
```
const partialDepth = (payload, cb) => {
  const cache = (Array.isArray(payload) ? payload : [payload]).map(({ symbol, level }) => {
    const w = openWebSocket(`${BASE}/${symbol.toLowerCase()}@depth${level}`)
```