### PR TITLE
chore(typings): Expose error codes

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,6 +2,49 @@
 declare module 'binance-api-node' {
     export default function (options?: { apiKey: string; apiSecret: string }): Binance;
 
+    export enum ErrorCodes {
+        UNKNOWN = -1000,
+        DISCONNECTED = -1001,
+        UNAUTHORIZED = -1002,
+        TOO_MANY_REQUESTS = -1003,
+        UNEXPECTED_RESP = -1006,
+        TIMEOUT = -1007,
+        INVALID_MESSAGE = -1013,
+        UNKNOWN_ORDER_COMPOSITION = -1014,
+        TOO_MANY_ORDERS = -1015,
+        SERVICE_SHUTTING_DOWN = -1016,
+        UNSUPPORTED_OPERATION = -1020,
+        INVALID_TIMESTAMP = -1021,
+        INVALID_SIGNATURE = -1022,
+        ILLEGAL_CHARS = -1100,
+        TOO_MANY_PARAMETERS = -1101,
+        MANDATORY_PARAM_EMPTY_OR_MALFORMED = -1102,
+        UNKNOWN_PARAM = -1103,
+        UNREAD_PARAMETERS = -1104,
+        PARAM_EMPTY = -1105,
+        PARAM_NOT_REQUIRED = -1106,
+        NO_DEPTH = -1112,
+        TIF_NOT_REQUIRED = -1114,
+        INVALID_TIF = -1115,
+        INVALID_ORDER_TYPE = -1116,
+        INVALID_SIDE = -1117,
+        EMPTY_NEW_CL_ORD_ID = -1118,
+        EMPTY_ORG_CL_ORD_ID = -1119,
+        BAD_INTERVAL = -1120,
+        BAD_SYMBOL = -1121,
+        INVALID_LISTEN_KEY = -1125,
+        MORE_THAN_XX_HOURS = -1127,
+        OPTIONAL_PARAMS_BAD_COMBO = -1128,
+        INVALID_PARAMETER = -1130,
+        BAD_API_ID = -2008,
+        DUPLICATE_API_KEY_DESC = -2009,
+        INSUFFICIENT_BALANCE = -2010,
+        CANCEL_ALL_FAIL = -2012,
+        NO_SUCH_ORDER = -2013,
+        BAD_API_KEY_FMT = -2014,
+        REJECTED_MBX_KEY = -2015,
+    }
+
     export interface Account {
         balances: AssetBalance[];
         buyerCommission: number;


### PR DESCRIPTION
Hello and a happy new year! 🎉 

With this PR the following will be possible when using the Binance API in TypeScript:

```ts
import {ErrorCodes} from 'binance-api-node';
console.log('Error code', ErrorCodes.INSUFFICIENT_BALANCE);
```