### PR TITLE
chore(typings): Add properties to "MIN_NOTIONAL" filter

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -258,6 +258,8 @@ declare module 'binance-api-node' {
     }
 
     export interface SymbolMinNotionalFilter {
+        applyToMarket: boolean;
+        avgPriceMins: number;
         filterType: SymbolFilterType;
         minNotional: string;
     }


### PR DESCRIPTION
The `'MIN_NOTIONAL'` filter was missing the properties `applyToMarket` and `avgPriceMins` which have been added to the Binance API:
- https://github.com/binance-exchange/binance-official-api-docs/blob/master/rest-api.md#min_notional