### PR TITLE
docs(readme): Update "getOrder" payload

### DIFF
--- a/README.md
+++ b/README.md
@@ -512,8 +512,8 @@ Check an order's status.
 
 ```js
 console.log(await client.getOrder({
-  symbol: 'ETHBTC',
-  orderId: 1,
+  symbol: 'BNBETH',
+  orderId: 50167927,
 }))
 ```
 
@@ -529,20 +529,24 @@ console.log(await client.getOrder({
 
 ```js
 {
-  symbol: 'ENGETH',
-  orderId: 191938,
-  clientOrderId: '1XZTVBTGS4K1e',
-  price: '0.00138000',
-  origQty: '1.00000000',
-  executedQty: '1.00000000',
+  clientOrderId: 'NkQnNkdBV1RGjUALLhAzNy',
+  cummulativeQuoteQty: '0.16961580',
+  executedQty: '3.91000000',
+  icebergQty: '0.00000000',
+  isWorking: true,
+  orderId: 50167927,
+  origQty: '3.91000000',
+  price: '0.04338000',
+  side: 'SELL',
   status: 'FILLED',
+  stopPrice: '0.00000000',
+  symbol: 'BNBETH',
+  time: 1547075007821,
   timeInForce: 'GTC',
   type: 'LIMIT',
-  side: 'SELL',
-  stopPrice: '0.00000000',
-  icebergQty: '0.00000000',
-  time: 1508611114735
+  updateTime: 1547075016737
 }
+
 ```
 
 </details>


### PR DESCRIPTION
I updated the payload with a real-world example which I logged. The payload now contains the additional `updateTime` and `cummulativeQuoteQty` which are part of the Binance API:
- https://github.com/binance-exchange/binance-official-api-docs/blob/master/rest-api.md#query-order-user_data

In general we should consider linking to Binance's response examples (or the definitions of our [index.d.ts](https://github.com/HyperCubeProject/binance-api-node/blob/master/index.d.ts) file) instead of maintaining our own payloads in a Markdown file.