### PR TITLE
chore: Require yarn

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,9 @@
     "prettier": "^1.7.4",
     "rimraf": "^2.6.2"
   },
+  "engines": {
+    "yarn": ">= 1.0.0"
+  },
   "ava": {
     "require": [
       "babel-register",

--- a/package.json
+++ b/package.json
@@ -5,10 +5,10 @@
   "main": "dist",
   "scripts": {
     "build": "rimraf dist && babel src -d dist",
-    "prepare": "npm run build",
-    "test": "ava",
+    "prepare": "yarn build",
+    "test": "ava --timeout=10s",
     "cover": "nyc ava",
-    "report": "npm run cover && nyc report --reporter=text-lcov | coveralls",
+    "report": "yarn cover && nyc report --reporter=text-lcov | coveralls",
     "lint": "eslint src"
   },
   "dependencies": {


### PR DESCRIPTION
The project carries a `yarn.lock` file, so it is important that yarn is being used to retrieve third-party dependencies, that's why I added `yarn` to the `engines` field.

I also replaced `npm run` with `yarn` because it does the same but relies on yarn for execution.

Besides that, I added a timeout when running tests with ava to flag broken tests which may end up in loops.