### PR TITLE
Add support for the optional field 'timeOffset' to be used in private calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ const client = Binance()
 const client2 = Binance({
   apiKey: 'xxx',
   apiSecret: 'xxx',
-  timeOffset: xxx // difference between local time and server time, optional, defaults to 0
+  getTime: xxx // time generator function, optional, defaults to () => Date.now()
 })
 
 client.time().then(time => console.log(time))

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ const client = Binance()
 const client2 = Binance({
   apiKey: 'xxx',
   apiSecret: 'xxx',
+  timeOffset: xxx // difference between local time and server time, optional, defaults to 0
 })
 
 client.time().then(time => console.log(time))

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,6 @@
 // tslint:disable:interface-name
 declare module 'binance-api-node' {
-    export default function (options?: { apiKey: string; apiSecret: string, timeOffset?: number }): Binance;
+    export default function (options?: { apiKey: string; apiSecret: string, getTime?: () => number }): Binance;
 
     export enum ErrorCodes {
         UNKNOWN = -1000,

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,6 @@
 // tslint:disable:interface-name
 declare module 'binance-api-node' {
-    export default function (options?: { apiKey: string; apiSecret: string }): Binance;
+    export default function (options?: { apiKey: string; apiSecret: string, timeOffset?: number }): Binance;
 
     export enum ErrorCodes {
         UNKNOWN = -1000,

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,6 @@
 // tslint:disable:interface-name
 declare module 'binance-api-node' {
-    export default function (options?: { apiKey: string; apiSecret: string, getTime?: () => number }): Binance;
+    export default function (options?: { apiKey: string; apiSecret: string, getTime?: () => number | Promise<number> }): Binance;
 
     export enum ErrorCodes {
         UNKNOWN = -1000,

--- a/src/http.js
+++ b/src/http.js
@@ -91,7 +91,7 @@ const keyCall = ({ apiKey }) => (path, data, method = 'GET') => {
  * @param {object} headers
  * @returns {object} The api response
  */
-const privateCall = ({ apiKey, apiSecret }) => (
+const privateCall = ({ apiKey, apiSecret, timeOffset = 0 }) => (
   path,
   data = {},
   method = 'GET',
@@ -104,7 +104,7 @@ const privateCall = ({ apiKey, apiSecret }) => (
 
   return (data && data.useServerTime
     ? publicCall('/v1/time').then(r => r.serverTime)
-    : Promise.resolve(Date.now())
+    : Promise.resolve(Date.now() - timeOffset)
   ).then(timestamp => {
     if (data) {
       delete data.useServerTime

--- a/src/http.js
+++ b/src/http.js
@@ -5,6 +5,8 @@ import 'isomorphic-fetch'
 
 const BASE = 'https://api.binance.com'
 
+const defaultGetTime = () => Date.now()
+
 /**
  * Build query string for uri encoded url based on json object
  */
@@ -91,7 +93,7 @@ const keyCall = ({ apiKey }) => (path, data, method = 'GET') => {
  * @param {object} headers
  * @returns {object} The api response
  */
-const privateCall = ({ apiKey, apiSecret, getTime = () => Date.now() }) => (
+const privateCall = ({ apiKey, apiSecret, getTime }) => (
   path,
   data = {},
   method = 'GET',
@@ -104,7 +106,7 @@ const privateCall = ({ apiKey, apiSecret, getTime = () => Date.now() }) => (
 
   return (data && data.useServerTime
     ? publicCall('/v1/time').then(r => r.serverTime)
-    : Promise.resolve(getTime())
+    : Promise.resolve(typeof getTime === 'function' ? getTime() : defaultGetTime())
   ).then(timestamp => {
     if (data) {
       delete data.useServerTime

--- a/src/http.js
+++ b/src/http.js
@@ -91,7 +91,7 @@ const keyCall = ({ apiKey }) => (path, data, method = 'GET') => {
  * @param {object} headers
  * @returns {object} The api response
  */
-const privateCall = ({ apiKey, apiSecret, timeOffset = 0 }) => (
+const privateCall = ({ apiKey, apiSecret, getTime = () => Date.now() }) => (
   path,
   data = {},
   method = 'GET',
@@ -104,7 +104,7 @@ const privateCall = ({ apiKey, apiSecret, timeOffset = 0 }) => (
 
   return (data && data.useServerTime
     ? publicCall('/v1/time').then(r => r.serverTime)
-    : Promise.resolve(Date.now() - timeOffset)
+    : Promise.resolve(getTime())
   ).then(timestamp => {
     if (data) {
       delete data.useServerTime

--- a/src/http.js
+++ b/src/http.js
@@ -93,7 +93,7 @@ const keyCall = ({ apiKey }) => (path, data, method = 'GET') => {
  * @param {object} headers
  * @returns {object} The api response
  */
-const privateCall = ({ apiKey, apiSecret, getTime }) => (
+const privateCall = ({ apiKey, apiSecret, getTime = defaultGetTime }) => (
   path,
   data = {},
   method = 'GET',
@@ -106,7 +106,7 @@ const privateCall = ({ apiKey, apiSecret, getTime }) => (
 
   return (data && data.useServerTime
     ? publicCall('/v1/time').then(r => r.serverTime)
-    : Promise.resolve(typeof getTime === 'function' ? getTime() : defaultGetTime())
+    : Promise.resolve(getTime())
   ).then(timestamp => {
     if (data) {
       delete data.useServerTime


### PR DESCRIPTION
This support for the optional field `timeOffset` allows consumers of the API to avoid unnecessary calls to the `/api/v1/time` endpoint for each private call. One can call the `time` method only once at startup and then calculate an offset between the local time and the returned value which, if provided as an option, will be used for any future private call.